### PR TITLE
Updating README and making the service only handle a single endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ TK -->
 
 This is the frontend code that sets the parameters to run the MSIS model in AWS.
 
-A Flask backend has been set up to create an API that receives GET requests with the model parameters and returns a GET request with the result.
+A serverless backend has been set up to create an API that receives POST requests with the model parameters and returns a POST response with the results.
 
 ## Running MSIS Locally
 

--- a/src/app/services/model/model.service.ts
+++ b/src/app/services/model/model.service.ts
@@ -10,22 +10,8 @@ export class ModelService {
 
     constructor(private http: HttpClient) { }
 
-    submitSinglePointRequest( payload: any, id?: string ) {
-        const url = id ? '/singlepoint/' + id : '/singlepoint';
-        return this.http.post<any>( environment.msisApi + url , payload);
+    submitRequest( payload: any, id?: string ) {
+        return this.http.post<any>( environment.msisApi , payload);
     }
 
-    submitGeometryFile( name: string, file?: any ) {
-        if ( file ) {
-            const formData = new FormData();
-            formData.append('file', file);
-            return this.http.post<any>( environment.msisApi + '/geometry', formData );
-        } else {
-            return this.http.post<any>( environment.msisApi + '/geometry/' + name, {});
-        }
-    }
-
-    getImage( id: string ) {
-        return this.http.get<any>( environment.msisApi + '/image/' + id, { responseType: 'blob' as 'json' } );
-    }
 }


### PR DESCRIPTION
It looks like I named the other repo properly already and it should just fall into place I hope!

I'm not entirely sure what to do for the documentation of the code. It is not our code, so we don't have as great of a spot to link to. Rather than Markdown, what about just linking to the NRL page? https://www.nrl.navy.mil/ssd/branches/7630/modeling-upper-atmosphere
It still doesn't really have a good description though.