### PR TITLE
Adding surface and altitude requests to the model service

### DIFF
--- a/src/app/services/model/model.service.ts
+++ b/src/app/services/model/model.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
+import { _getOptionScrollPosition } from '@angular/material/core';
 
 @Injectable({
     providedIn: 'root'
@@ -10,8 +11,33 @@ export class ModelService {
 
     constructor(private http: HttpClient) { }
 
-    submitRequest( payload: any, id?: string ) {
-        return this.http.post<any>( environment.msisApi , payload);
+    submitSurfaceRequest(date: Date, altitude: number, f107: number, f107a: number,
+        ap: number, options: number[]) {
+        return this.http.get<any>(environment.msisApi + '/surface', {
+            params: {
+                "date": date.toISOString(), // might need to put in setSeconds(0) and milliseconds?
+                "altitude": altitude.toString(),
+                "f107": f107.toString(),
+                "f107a": f107a.toString(),
+                "ap": ap.toString(),
+                "options": options.toString()
+            }
+        })
     }
 
+    submitAltitudeRequest(date: Date, longitude: number, latitude: number,
+        f107: number, f107a: number,
+        ap: number, options: number[]) {
+        return this.http.get<any>(environment.msisApi + '/altitude', {
+            params: {
+                "date": date.toISOString(), // might need to put in setSeconds(0) and milliseconds?
+                "longitude": longitude.toString(),
+                "latitude": latitude.toString(),
+                "f107": f107.toString(),
+                "f107a": f107a.toString(),
+                "ap": ap.toString(),
+                "options": options.toString()
+            }
+        })
+    }
 }


### PR DESCRIPTION
This adds the new requests from the endpoints defined in the [msis-api](https://github.com/SWxTREC/msis-api). I'm not sure this is exactly how to use TypeScript, so feel free to just take this code and build off of it if you want.