### PR TITLE
add a reference to original source of data and a link to latis

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,15 +1,13 @@
 import { Component } from '@angular/core';
-
+import {
+    LaspBaseAppSnippetsService
+} from 'lasp-base-app-snippets';
 import {
     IImageLink,
     INavItem,
     ISocialLink,
     IVersion
 } from 'lasp-footer';
-
-import {
-    LaspBaseAppSnippetsService
-} from 'lasp-base-app-snippets';
 
 import { environment } from '../environments/environment';
 
@@ -20,6 +18,8 @@ import { environment } from '../environments/environment';
     styleUrls: [ './app.component.scss' ]
 })
 export class AppComponent {
+    latisLisird = environment.latisLisird;
+    latisSwp = environment.latisSwp;
 
     // please have no more than 7 items in the nav menu
     navItems: INavItem[] = [
@@ -52,10 +52,24 @@ export class AppComponent {
     versions: IVersion[] = [
         {
             version: environment.version
+        },
+        {
+            productName: 'Ap/ap data from GFZ German Research Centre for Geosciences provided via',
+            version:  'LaTiS-swp',
+            link: this.latisSwp,
+            linkedPart: 'version'
+        },
+        {
+            productName: 'Penticton F10.7 data from National Resources Canada provided via',
+            version: 'LaTiS-lisird',
+            link: this.latisLisird,
+            linkedPart: 'version'
         }
     ];
 
-    constructor( private _snippets: LaspBaseAppSnippetsService ) {
+    constructor(
+        private _snippets: LaspBaseAppSnippetsService
+    ) {
         this._snippets.appComponent.allExcept([ this._snippets.appComponent.setupGoogleAnalytics ]);
     }
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,10 +5,10 @@ import { version } from '../../package.json';
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-    latisSwp: 'https://swp-dev.pdmz.lasp.colorado.edu/space-weather-portal/latis/dap/',
-    // latisSwp: 'https://lasp.colorado.edu/space-weather-portal/latis/dap/',
-    // latisLisird: 'https://lasp.colorado.edu/lisird/latis/dap/',
-    latisLisird: 'http://lisird-stage.pdmz.lasp.colorado.edu/lisird/latis/dap/',
+    // latisSwp: 'https://swp-dev.pdmz.lasp.colorado.edu/space-weather-portal/latis/dap/',
+    // latisLisird: 'http://lisird-stage.pdmz.lasp.colorado.edu/lisird/latis/dap/',
+    latisSwp: 'https://lasp.colorado.edu/space-weather-portal/latis/dap/',
+    latisLisird: 'https://lasp.colorado.edu/lisird/latis/dap/',
     msisApi: 'https://uqw5ak3cjh.execute-api.us-east-1.amazonaws.com/Prod/msis2',
     production: false,
     version: version


### PR DESCRIPTION
This is kind of half-baked. I wanted to add a link to latis to show where the F10.7 and Ap data came from, and I thought it would be simple, but it opened up a can of worms of acknowledgment and attribution. The whole concept needs some more thought and probably more explicit documentation. 

For now, this PR puts the source of the data in a place where it is easy to link to Latis and reasonably findable but also unobtrusive (in the footer). I think it needs rethinking, but this was the easiest way to get it done for now. 