### PR TITLE
Latest ap

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,6 +8,9 @@ import {
     ISocialLink,
     IVersion
 } from 'lasp-footer';
+import {
+    LatisService
+} from 'src/app/services';
 
 import { environment } from '../environments/environment';
 
@@ -68,7 +71,9 @@ export class AppComponent {
     ];
 
     constructor(
-        private _snippets: LaspBaseAppSnippetsService
+        private _snippets: LaspBaseAppSnippetsService,
+        // trigger latis service on app load to get most recent ap data
+        private _latis: LatisService
     ) {
         this._snippets.appComponent.allExcept([ this._snippets.appComponent.setupGoogleAnalytics ]);
     }

--- a/src/app/containers/visualizer/components/swt-surface-plot/swt-surface-plot.component.ts
+++ b/src/app/containers/visualizer/components/swt-surface-plot/swt-surface-plot.component.ts
@@ -32,6 +32,7 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
     surfaceColor: d3.ScaleSequential<string>;
     pathFromProjection: d3.GeoPath<any, d3.GeoPermissibleObjects>;
     projection: d3.GeoProjection;
+    rotate = true;
 
     constructor(private elRef: ElementRef) {
         this.hostElement = this.elRef.nativeElement;
@@ -325,6 +326,7 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
         const initialScale = 170;
         // Drag
         this.g.call(d3.drag().on('drag', (event: any) => {
+            this.rotate = false;
             const rotate = this.projection.rotate();
             const k = sensitivity / this.projection.scale();
             this.projection.rotate([
@@ -346,13 +348,15 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
 
         // Automatic roation
         d3.timer( () => {
-            const rotate = this.projection.rotate();
-            const k = sensitivity / this.projection.scale();
-            this.projection.rotate([
-                rotate[0] - 1 * k,
-                rotate[1]
-            ]);
-            this.updateDraw();
+            if ( this.rotate ) {
+                const rotate = this.projection.rotate();
+                const k = sensitivity / this.projection.scale();
+                this.projection.rotate([
+                    rotate[0] - 1 * k,
+                    rotate[1]
+                ]);
+                this.updateDraw();
+            }
         }, 400);
     }
 

--- a/src/app/containers/visualizer/visualizer.container.html
+++ b/src/app/containers/visualizer/visualizer.container.html
@@ -17,6 +17,9 @@
             <input matInput type="number" formControlName="f107a">
             <mat-hint>81-day average solar radio flux at 10.7cm</mat-hint>
         </mat-form-field>
+        <mat-error *ngIf="!lastApDateWithValue">
+            <small>No pre-filled ap data available for this date. Select another date or manually fill in each value.</small>
+        </mat-error>
         <div class="viz__form-group" formGroupName="apForm">
             <mat-form-field floatLabel="always" class="viz__field">
                 <mat-label>Ap daily average</mat-label>

--- a/src/app/containers/visualizer/visualizer.container.ts
+++ b/src/app/containers/visualizer/visualizer.container.ts
@@ -40,7 +40,6 @@ export class VisualizerComponent implements OnInit {
     // extent of ap and penticton data
     invalidFieldMessage: string;
     invalidFields: string[];
-    // TODO: fix this to be the current day once Ap is updated to current day
     lastApDateWithValue: number;
     dataExtent: moment.Moment[];
     modelForm = new FormGroup({
@@ -154,7 +153,7 @@ export class VisualizerComponent implements OnInit {
                 debounceTime(300)
             ).subscribe( () => {
                 // I want this 'if' statement to be uneccessary…some day
-                if ( this.modelForm.controls.date && this.modelForm.controls.apForm ) {
+                if ( this.modelForm.controls.date && this.lastApDateWithValue && this.modelForm.controls.apForm ) {
                     this.modelService.submitSurfaceRequest( this.getSurfaceParams() ).subscribe( (results: ISurfaceData) => {
                         this.surfacePoints = cloneDeep(results);
                     });

--- a/src/app/containers/visualizer/visualizer.container.ts
+++ b/src/app/containers/visualizer/visualizer.container.ts
@@ -41,10 +41,10 @@ export class VisualizerComponent implements OnInit {
     invalidFieldMessage: string;
     invalidFields: string[];
     // TODO: fix this to be the current day once Ap is updated to current day
-    lastApDateWithValue: number = moment.utc('2020-10-15').startOf('day').valueOf();
-    dataExtent: moment.Moment[] = [ moment.utc('1947-01-01'), moment.utc(this.lastApDateWithValue) ];
+    lastApDateWithValue: number;
+    dataExtent: moment.Moment[];
     modelForm = new FormGroup({
-        date: new FormControl(this.dataExtent[1], [ Validators.required, Validators.min(0) ]),
+        date: new FormControl(undefined, [ Validators.required, Validators.min(0) ]),
         f107: new FormControl({ value: 75, disabled: true }, [ Validators.required, Validators.min(0) ]),
         f107a: new FormControl({ value: 75, disabled: true }, [ Validators.required, Validators.min(0) ]),
         apForm: new FormGroup({
@@ -84,14 +84,22 @@ export class VisualizerComponent implements OnInit {
     surfaceSvg: ISurfaceData;
     altitudeSvg: IAltitudeData;
     validDates = (d: moment.Moment | null): boolean => {
-        return d.isSameOrAfter(this.dataExtent[0]) && d.isSameOrBefore(this.dataExtent[1]);
+        if ( d && this.dataExtent ) {
+            return d.isSameOrAfter(this.dataExtent[0]) && d.isSameOrBefore(this.dataExtent[1]);
+        }
     }
-
 
     constructor(
         private modelService: ModelService,
         private latisService: LatisService
-    ) {}
+    ) {
+        this.latisService.mostRecentAp.subscribe( (timestamp: number) => {
+            this.lastApDateWithValue = timestamp;
+            this.dataExtent = [ moment.utc('1947-01-01'), moment.utc(this.lastApDateWithValue) ];
+            this.modelForm.controls.date.setValue(this.dataExtent[1]);
+        });
+
+    }
 
     ngOnInit() {
         const initialMomentDate: moment.Moment = this.dataExtent[1];

--- a/src/app/services/latis/latis.service.ts
+++ b/src/app/services/latis/latis.service.ts
@@ -1,14 +1,21 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import * as moment from 'moment';
+import { BehaviorSubject } from 'rxjs';
 import { environment } from 'src/environments/environment';
 
 @Injectable({
     providedIn: 'root'
 })
 export class LatisService {
+    mostRecentAp: BehaviorSubject<number> = new BehaviorSubject(undefined);
 
-    constructor(private http: HttpClient) {}
+    constructor(private http: HttpClient) {
+        // get the most recent ap value on app load
+        this.http.get(`${environment.latisSwp}ap.jsond?last()`).subscribe( (response: any) => {
+            this.mostRecentAp.next(response.ap.data[ 0 ][ 0 ]);
+        });
+    }
 
     getApValues( endDate: number ) {
         const startDate: number = endDate - ( 1000 * 60 * 60 * 24 * 5 );
@@ -21,7 +28,7 @@ export class LatisService {
         const startDate: number = moment.utc(date).startOf('day').valueOf();
         const endDate: number = moment.utc(date).endOf('day').valueOf();
         const timeQuery: string = this.getTimeQuery( startDate, endDate );
-        // return all of the Ap readings from selected date (up to 8 every 24 hours)
+        // return all of the ap readings from selected date (up to 8 every 24 hours)
         return this.http.get(`${environment.latisSwp}ap.jsond?${ timeQuery }`);
     }
 

--- a/src/app/services/latis/latis.service.ts
+++ b/src/app/services/latis/latis.service.ts
@@ -13,7 +13,11 @@ export class LatisService {
     constructor(private http: HttpClient) {
         // get the most recent ap value on app load
         this.http.get(`${environment.latisSwp}ap.jsond?last()`).subscribe( (response: any) => {
-            this.mostRecentAp.next(response.ap.data[ 0 ][ 0 ]);
+            // if there is a value, use that date,
+            // otherwise app will default to today and show warning that no pre-filled data is available
+            if ( response.ap.data[0][1] ) {
+                this.mostRecentAp.next(response.ap.data[ 0 ][ 0 ]);
+            }
         });
     }
 


### PR DESCRIPTION
This PR updates the valid dates to include the most recent data from the ap index. :+1: Previously, the most recent date was hard coded to October 2020. :-1:

Now, on app load, it will look for the most recent available ap data and use the last date with a value as the default date (about a 2 week+ lag at this point). If there is no value for the most recent date, the app defaults to today and no data is shown until either (1) the user selects a day with data or (2) manually fills in all the ap values. 

This also adds a simple attribute that will stop the globe from rotating once the globe is dragged (not zoomed) for the first time. I have a branch with a play button that appears when the globe is stopped, and then the play button can be clicked to start it rotating again, but the code was slightly more complicated than I wanted it to be, so this a starting interaction, for now. Play button to come, if/when we want that. 