### PR TITLE
FIX: Change d3.Timer to d3.Interval

### DIFF
--- a/src/app/containers/visualizer/components/swt-surface-plot/swt-surface-plot.component.ts
+++ b/src/app/containers/visualizer/components/swt-surface-plot/swt-surface-plot.component.ts
@@ -32,7 +32,7 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
     surfaceColor: d3.ScaleSequential<string>;
     pathFromProjection: d3.GeoPath<any, d3.GeoPermissibleObjects>;
     projection: d3.GeoProjection;
-    rotate = true;
+    timer: d3.Timer;
 
     constructor(private elRef: ElementRef) {
         this.hostElement = this.elRef.nativeElement;
@@ -332,7 +332,8 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
         const initialScale = 170;
         // Drag
         this.g.call(d3.drag().on('drag', (event: any) => {
-            this.rotate = false;
+            // stop the timer
+            this.timer.stop();
             const rotate = this.projection.rotate();
             const k = sensitivity / this.projection.scale();
             this.projection.rotate([
@@ -355,18 +356,16 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
         );
         this.g.on('dblclick.zoom', null);
 
-        // Automatic rotation
-        d3.timer( () => {
-            if ( this.rotate ) {
-                const rotate = this.projection.rotate();
-                const k = sensitivity / this.projection.scale();
-                this.projection.rotate([
-                    rotate[0] - 1 * k,
-                    rotate[1]
-                ]);
-                this.updateDraw();
-            }
-        }, 400);
+        // Automatic roation
+        this.timer = d3.interval( () => {
+            const rotate = this.projection.rotate();
+            const k = sensitivity / this.projection.scale();
+            this.projection.rotate([
+                rotate[0] - 1 * k,
+                rotate[1]
+            ]);
+            this.updateDraw();
+        }, 200);
     }
 
     setInitialSvg(): void {


### PR DESCRIPTION
- The interval is more appropriate for running an update every X seconds
- Change the rotation time to 200 ms
- Just call timer.stop() when we want to stop the rotation