### PR TITLE
Fix the bug related to updates

### DIFF
--- a/src/app/containers/visualizer/components/swt-surface-plot/swt-surface-plot.component.ts
+++ b/src/app/containers/visualizer/components/swt-surface-plot/swt-surface-plot.component.ts
@@ -43,19 +43,17 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
     }
 
     ngOnChanges( changes: SimpleChanges ) {
+        if ( changes.date && !changes.date.firstChange ) {
+            this.setProjection();
+            this.g2.selectAll('.lonLine').remove();
+            this.g2.selectAll('.lonLineText').remove();
+            this.drawLongitudeLines();
+            this.updateDraw();
+        }
         if (this.data) {
-            console.log({ changes });
-            if ( changes.date ) {
-                this.setProjection();
-                console.log('draw longitude lines');
-                this.drawLongitudeLines();
-            }
             this.setSurfaceCells(this.data);
             this.fillSurfaceCells();
             this.drawColorBar();
-            if ( changes.latitude || changes.longitude ) {
-            }
-            console.log('draw altitude box');
             this.drawAltitudeBox();
         }
     }
@@ -172,7 +170,7 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
             .attr('dy', '0.8rem')
             .attr('font-size', '100%')
             .attr('text-anchor', 'middle')
-            .text(function(d) { return d.properties.name; });
+            .text(d => d.properties.name);
     }
 
     drawMap() {
@@ -409,10 +407,9 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
         this.pathFromProjection = d3.geoPath(this.projection);
         // update all the geopaths
         this.svg.selectAll('path').attr('d', this.pathFromProjection);
-        const proj = this.projection;
         this.svg.selectAll('.lonLineText')
-            .attr('x', function(d: any) { return proj([ d.properties.longitude, 50 ])[0]; })
-            .attr('y', function(d: any) { return proj([ d.properties.longitude, 50 ])[1]; });
+            .attr('x', (d: any) => this.projection([ d.properties.longitude, 50 ])[0] )
+            .attr('y', (d: any) => this.projection([ d.properties.longitude, 50 ])[1] );
     }
 
     updateLegend() {

--- a/src/app/containers/visualizer/components/swt-surface-plot/swt-surface-plot.component.ts
+++ b/src/app/containers/visualizer/components/swt-surface-plot/swt-surface-plot.component.ts
@@ -32,7 +32,7 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
     surfaceColor: d3.ScaleSequential<string>;
     pathFromProjection: d3.GeoPath<any, d3.GeoPermissibleObjects>;
     projection: d3.GeoProjection;
-    rotate = true;
+    timer: d3.Timer;
 
     constructor(private elRef: ElementRef) {
         this.hostElement = this.elRef.nativeElement;
@@ -326,7 +326,8 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
         const initialScale = 170;
         // Drag
         this.g.call(d3.drag().on('drag', (event: any) => {
-            this.rotate = false;
+            // stop the timer
+            this.timer.stop();
             const rotate = this.projection.rotate();
             const k = sensitivity / this.projection.scale();
             this.projection.rotate([
@@ -347,17 +348,15 @@ export class SwtSurfacePlotComponent implements OnChanges, OnInit {
         }));
 
         // Automatic roation
-        d3.timer( () => {
-            if ( this.rotate ) {
-                const rotate = this.projection.rotate();
-                const k = sensitivity / this.projection.scale();
-                this.projection.rotate([
-                    rotate[0] - 1 * k,
-                    rotate[1]
-                ]);
-                this.updateDraw();
-            }
-        }, 400);
+        this.timer = d3.interval( () => {
+            const rotate = this.projection.rotate();
+            const k = sensitivity / this.projection.scale();
+            this.projection.rotate([
+                rotate[0] - 1 * k,
+                rotate[1]
+            ]);
+            this.updateDraw();
+        }, 200);
     }
 
     setInitialSvg(): void {


### PR DESCRIPTION
This PR fixes the bug where the altitude box wasn't updating. It also fixes the bug where if you drag the globe first, then change the date, the longitude lines did not update. 

I don't love the way this is done. It is a bit heavy handed—removing and redrawing the longitude lines and labels, then updating the labels again in `updateDraw()` on each date change, redrawing the altitude box on every data change—but it works. 

I am sure there is some clever d3 `enter().merge().exit().remove()` way to do it, but I couldn't figure it out today. 

`npm start` and the altitude box will appear and update as normal. 
- Change the date on the rotating globe and the longitude lines and labels will update and the altitude box will continue to function normally. 
- Refresh. Drag globe. Altitude box functions normally.
- Change date. Longitude lines and labels update and altitude box continues to function normally. 