### PR TITLE
Bugfix/ap zero

### DIFF
--- a/src/app/containers/visualizer/visualizer.container.html
+++ b/src/app/containers/visualizer/visualizer.container.html
@@ -13,9 +13,14 @@
             <input matInput type="number" formControlName="f107a">
             <mat-hint>81-day average solar radio flux at 10.7cm</mat-hint>
         </mat-form-field>
-        <mat-error *ngIf="!lastApDateWithValue">
-            <small>No pre-filled ap data available for this date. Select another date or manually fill in each value.</small>
-        </mat-error>
+        <div class="viz__error-group">
+            <mat-error *ngIf="!lastApDateWithValue">
+                <small>No pre-filled ap data available for this date. Select another date or manually fill in each value.</small>
+            </mat-error>
+            <mat-error *ngIf="modelForm.controls.apForm.invalid">
+                <small>Each ap value must be defined.</small>
+            </mat-error>
+        </div>
         <div class="viz__form-group" formGroupName="apForm">
             <mat-form-field floatLabel="always" class="viz__field">
                 <mat-label>Ap daily average</mat-label>

--- a/src/app/containers/visualizer/visualizer.container.scss
+++ b/src/app/containers/visualizer/visualizer.container.scss
@@ -35,6 +35,11 @@ $helper-font-size: 8pt;
         position: absolute;
         right: 20px;
     }
+    &__error-group {
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
+    }
     &__field {
         width: 150px;
         &:not(:last-child) {

--- a/src/app/services/latis/latis.service.ts
+++ b/src/app/services/latis/latis.service.ts
@@ -16,7 +16,7 @@ export class LatisService {
         this.http.get(`${environment.latisSwp}ap.jsond?last()`).pipe(take(1)).subscribe( (response: any) => {
             // if there is a value, use that date,
             // otherwise app will default to today and show warning that no pre-filled data is available
-            if ( response.ap.data[0][1] ) {
+            if ( response.ap.data[0][1] != null ) {
                 this.mostRecentAp.next(response.ap.data[ 0 ][ 0 ]);
             }
         });


### PR DESCRIPTION
This PR removes the error that assumed there was no ap value when there was an ap value of 0. It works again!

However, if there is no ap value, the app will default to today and ask you to manually fill in the ap values. 

To test this, go to the Network tab in the dev tools and look for the `ap.jsond?last()` request. Right click on the request, choose to block the request url, and refresh. 

You will see the error messages. 

Manually fill in the values. After you fill in the final value, the request will be made, the message to fill in all the values will disappear and the globe's colors will load based on your inputs. 

Right click on the request again and select unblock, to unblock the request in your browser. 