### PR TITLE
SWT-187 add option to download CSV data

### DIFF
--- a/src/app/containers/visualizer/visualizer.container.html
+++ b/src/app/containers/visualizer/visualizer.container.html
@@ -90,7 +90,13 @@
                         [value]="variable"
                     >{{ variable }}</mat-button-toggle>
                 </mat-button-toggle-group>
-                <button mat-icon-button matTooltip="Download surface plot" class="viz__download" (click)="downloadSvg('surfacePlot')"><mat-icon>download</mat-icon></button>
+                <div class="viz__download">
+                    <button mat-button [matMenuTriggerFor]="menu" matTooltip="Download options"><mat-icon>download</mat-icon></button>
+                    <mat-menu #menu="matMenu">
+                      <button mat-menu-item (click)="downloadSvg('surfacePlot')">Image as SVG</button>
+                      <button mat-menu-item (click)="downloadData('surfacePlot')">Data as CSV</button>
+                    </mat-menu>
+                </div>
             </mat-toolbar-row>
         </mat-toolbar>
     </mat-card>


### PR DESCRIPTION
This PR adds an option to download the MSIS data as a CSV. 

to demo: `npm install && npm start` then open `localhost://4200` in your browser, go to visualizer and choose your download option. 